### PR TITLE
Fix unrolling

### DIFF
--- a/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
+++ b/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
@@ -94,8 +94,11 @@ class LinCombFull(CircuitQFI):
         qr_work = QuantumRegister(1, "work_qubit")
         state_qc = QuantumCircuit(*operator.primitive.qregs, qr_work)
         state_qc.h(qr_work)
-        state_qc.compose(operator.primitive, inplace=True)
-        state_qc = LinComb._unroll_to_supported_operations(state_qc, LinComb.SUPPORTED_GATES)
+        # unroll separately from the H gate since we need the H gate to be the first
+        # operation in the data attributes of the circuit
+        unrolled = LinComb._unroll_to_supported_operations(
+            operator.primitive, LinComb.SUPPORTED_GATES)
+        state_qc.compose(unrolled, inplace=True)
 
         # Get the circuits needed to compute〈∂iψ|∂jψ〉
         for i, param_i in enumerate(params):  # loop over parameters


### PR DESCRIPTION
by unrolling the circuit separately from the additional hadamard gate

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

* include missing CX (and some others) in LinComb
* unroll circuit w/o hadamard gate to preserve logical order of gates

### Details and comments


